### PR TITLE
Only prevent default keypress for enter/escape

### DIFF
--- a/src/js/exprecss.js
+++ b/src/js/exprecss.js
@@ -143,23 +143,24 @@
 			if (cancelText) {
 				$document.on('keypress', function onEsc(e) {
 					if (e.which === 27) {
+                        e.preventDefault();
 						cancel();
 						$document.off('keypress', onEsc);
 					} else if (e.which === 13) {
+                        e.preventDefault();
 						confirm();
 						$document.off('keypress', onEsc);
 					}
-                    e.preventDefault();
 				});
 				$expModal.showOverlay(cancel);
 			} else {
 				$expModal.showOverlay(confirm);
 				$document.on('keypress', function onEsc(e) {
                     if (e.which === 27 || e.which === 13) {
+                        e.preventDefault();
                         confirm();
                         $document.off('keypress', onEsc);
 					}
-                    e.preventDefault();
 				});
 			}
 


### PR DESCRIPTION
- The function preventDefault() should only fire on the keypress events for the enter and escape keys.
- Before this, the prevent default function was preventing normal keypresses from working on background forms.