### PR TITLE
Create a wrapper function for generic server errors

### DIFF
--- a/src/js/exprecss.js
+++ b/src/js/exprecss.js
@@ -92,6 +92,12 @@
 		};
 	});
 
+    app.factory('$expAlertServerError', function($expConfirm){
+        return function() {
+            return $expConfirm('Error', 'An unexpected error has occurred.', 'Okay', null, {headerClass: 'modal-header-important'});
+        }
+    });
+
 	app.factory('$expConfirm', function($q, $rootScope, $compile, $expModal, $document, $sce, $timeout) {
 		var $expConfirm = function(title, html, confirmText, cancelText, options) {
 			var deferred = $q.defer(),


### PR DESCRIPTION
- The function takes no arguments and simply pops up a generic modal stating 'An unexpected error has occurred.'