### PR TITLE
Use an empty function instead of null when clearing the close function

### DIFF
--- a/src/js/exprecss.js
+++ b/src/js/exprecss.js
@@ -72,7 +72,7 @@
 
         this.hideOverlay = scope.hideOverlay = function() {
             scope.closeCurrentModal = null;
-            scope.showOverlay = false;
+            scope.showOverlay = function(){ /* empty since there is nothing to close */ };
         };
 
         this.close = scope.close = function(){


### PR DESCRIPTION
- Otherwise, attempting to execute it will lead to a null pointer error